### PR TITLE
Prevent from stuck in loop

### DIFF
--- a/lastwake.py
+++ b/lastwake.py
@@ -95,11 +95,14 @@ suspendTimes = []
 wakeTimes = []
 
 for entry in j:
-    # print(str(entry['__REALTIME_TIMESTAMP'] )+ ' ' + entry['MESSAGE'])
-    if "Suspending system..." in entry['MESSAGE']:
-        suspendTimes.append(entry['__REALTIME_TIMESTAMP'])
-    if "Finishing wakeup" in entry['MESSAGE']:
-        wakeTimes.append(entry['__REALTIME_TIMESTAMP'])
+    try:
+        # print(str(entry['__REALTIME_TIMESTAMP'] )+ ' ' + entry['MESSAGE'])
+        if "Suspending system..." in str(entry['MESSAGE']):
+            suspendTimes.append(entry['__REALTIME_TIMESTAMP'])
+        if "Finishing wakeup" in str(entry['MESSAGE']):
+            wakeTimes.append(entry['__REALTIME_TIMESTAMP'])
+    except:
+        continue
 
 
 spinningCursor.stop()


### PR DESCRIPTION
If the log is corrupt you can get stuck in an inifinite loop
see below:

```
$ ./lastwake 

Wake/Suspend Time SystemD Journal Analyzer [current boot]

Initial Boot Timestamp:  2016-08-26 23:31:12 

[Analyzing Journal] ...-Traceback (most recent call last):
  File "/usr/bin/lastwake", line 99, in <module>
    if "Suspending system..." in entry['MESSAGE']:
TypeError: a bytes-like object is required, not 'str'
[Analyzing Journal] ...^CException ignored in: <module 'threading' from 
'/usr/lib/python3.5/threading.py'>
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 1288, in _shutdown
    t.join()
  File "/usr/lib/python3.5/threading.py", line 1054, in join
    self._wait_for_tstate_lock()
  File "/usr/lib/python3.5/threading.py", line 1070, in _wait_for_tstate_lock
    elif lock.acquire(block, timeout):
KeyboardInterrupt
```

i added a quick fix to prevent getting stuck
